### PR TITLE
--dest=<PATH> CLI option to build to <PATH>; defaults to "dist"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
+.git
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-node_modules
 .git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+
+FROM node:6.9.1
+
+RUN apt-get update && apt-get install -y \
+  git \
+  curl
+
+RUN npm install yarn phantomjs bower --global
+
+ENV TEMPLATES_COMPILE_DESTINATION /var/templates/dist
+
+VOLUME $TEMPLATES_COMPILE_DESTINATION
+
+RUN mkdir -p /var/templates/src
+
+WORKDIR /var/templates/src
+
+ADD . /var/templates/src
+
+RUN npm install && bower --allow-root install && node_modules/.bin/gulp build --dest=/var/templates/dist --production --no_styleguide
+
+CMD ["node_modules/.bin/gulp", "--dest=/var/templates/dist", "--no_styleguide"]
+
+
+
+
+

--- a/bower.json
+++ b/bower.json
@@ -16,14 +16,15 @@
   ],
   "dependencies": {
     "countdown": "^2.1.0",
-    "duo_php": "git@github.com:duosecurity/duo_php.git#master",
     "font-awesome": "^4.6.1",
-    "iframe-resizer": "^3.5.3",
     "motion-ui": "~1.1.0",
     "webshim": "~1.15.10",
     "sass-toolkit": "~2.9.0",
     "what-input": "^1.2.5",
     "zxcvbn": "~4.2.0"
+  },
+  "resolutions": {
+    "jquery": "2.1.4"
   },
   "private": true
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -32,7 +32,7 @@ function loadConfig() {
   return yaml.load(ymlFile);
 }
 
-let buildSeries = [
+const buildSeries = [
   clean,
   gulp.parallel(pages, sass, javascript, copy, copyBower)
 ].concat(NO_STYLEGUIDE ? [] : [styleGuide]);

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -34,7 +34,7 @@ function loadConfig() {
 
 const buildSeries = [
   clean,
-  gulp.parallel(pages, sass, javascript, copy, copyBower)
+  gulp.parallel(pages, sass, javascript, images, copy, copyBower)
 ].concat(NO_STYLEGUIDE ? [] : [styleGuide]);
 
 // Build the "dist" folder by running all of the below tasks

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,6 +11,8 @@ import sherpa   from 'style-sherpa';
 import yaml     from 'js-yaml';
 import fs       from 'fs';
 import access   from 'gulp-accessibility';
+import path     from 'path';
+
 // import arialinter  from 'gulp-arialinter';
 
 // Load all Gulp plugins into one variable
@@ -20,6 +22,7 @@ const $ = plugins();
 const PRODUCTION = !!(yargs.argv.production);
 
 const DESTINATION = yargs.argv.dest || 'dist';
+const NO_STYLEGUIDE = yargs.argv.no_styleguide;
 
 // Load settings from settings.yml
 const { COMPATIBILITY, PORT, UNCSS_OPTIONS, PATHS } = loadConfig();
@@ -29,9 +32,17 @@ function loadConfig() {
   return yaml.load(ymlFile);
 }
 
+let buildSeries = [
+  clean,
+  gulp.parallel(pages, sass, javascript, copy, copyBower)
+].concat(NO_STYLEGUIDE ? [] : [styleGuide]);
+
 // Build the "dist" folder by running all of the below tasks
 gulp.task('build',
- gulp.series(clean, gulp.parallel(pages, sass, javascript, images, copy, copyBower), styleGuide));
+  gulp.series.apply(gulp.series, buildSeries));
+
+//gulp.task('build',
+// gulp.series(clean, gulp.parallel(pages, sass, javascript, images, copy, copyBower), styleGuide));
 
 // Build the site, run the server, and watch for file changes
 gulp.task('default',
@@ -40,7 +51,7 @@ gulp.task('default',
 // Delete the "dist" folder
 // This happens every time a build starts
 function clean(done) {
-  rimraf(DESTINATION, done);
+  rimraf(path.join(DESTINATION, '*'), done);
 }
 
 // Copy files out of the assets folder

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,3 +1,4 @@
+/*eslint-env es6*/
 'use strict';
 
 import plugins  from 'gulp-load-plugins';
@@ -18,6 +19,8 @@ const $ = plugins();
 // Check for --production flag
 const PRODUCTION = !!(yargs.argv.production);
 
+const DESTINATION = yargs.argv.dest || 'dist';
+
 // Load settings from settings.yml
 const { COMPATIBILITY, PORT, UNCSS_OPTIONS, PATHS } = loadConfig();
 
@@ -37,19 +40,19 @@ gulp.task('default',
 // Delete the "dist" folder
 // This happens every time a build starts
 function clean(done) {
-  rimraf('dist', done);
+  rimraf(DESTINATION, done);
 }
 
 // Copy files out of the assets folder
 // This task skips over the "img", "js", and "scss" folders, which are parsed separately
 function copy() {
   return gulp.src(PATHS.assets)
-    .pipe(gulp.dest('dist/assets'));
+    .pipe(gulp.dest(`${DESTINATION}/assets`));
 }
 
 function copyBower() {
   return gulp.src(PATHS.bowerDirectLinked)
-    .pipe(gulp.dest('dist/assets/bower_components'));
+    .pipe(gulp.dest(`${DESTINATION}/assets/bower_components`));
 }
 
 // Copy page templates into finished HTML files
@@ -62,7 +65,7 @@ function pages() {
       data: 'src/data/',
       helpers: 'src/helpers/'
     }))
-    .pipe(gulp.dest('dist'));
+    .pipe(gulp.dest(DESTINATION));
 }
 
 // Load updated HTML templates and partials into Panini
@@ -74,7 +77,7 @@ function resetPages(done) {
 // Generate a style guide from the Markdown content and HTML template in styleguide/
 function styleGuide(done) {
   sherpa('src/styleguide/index.md', {
-    output: 'dist/styleguide.html',
+    output: `${DESTINATION}/styleguide.html`,
     template: 'src/styleguide/template.html'
   }, done);
 }
@@ -94,7 +97,7 @@ function sass() {
     .pipe($.if(PRODUCTION, $.uncss(UNCSS_OPTIONS)))
     .pipe($.if(PRODUCTION, $.cssnano()))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write()))
-    .pipe(gulp.dest('dist/assets/css'))
+    .pipe(gulp.dest(`${DESTINATION}/assets/css`))
     .pipe(browser.reload({ stream: true }));
 }
 
@@ -109,7 +112,7 @@ function javascript() {
       .on('error', e => { console.log(e); })
     ))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write()))
-    .pipe(gulp.dest('dist/assets/js'));
+    .pipe(gulp.dest(`${DESTINATION}/assets/js`));
 }
 
 // Copy images to the "dist" folder
@@ -119,13 +122,13 @@ function images() {
     .pipe($.if(PRODUCTION, $.imagemin({
       progressive: true
     })))
-    .pipe(gulp.dest('dist/assets/img'));
+    .pipe(gulp.dest(`${DESTINATION}/assets/img`));
 }
 
 // Start a server with BrowserSync to preview the site in
 function server(done) {
   browser.init({
-    server: 'dist', port: PORT
+    server: DESTINATION, port: PORT
   });
   done();
 }


### PR DESCRIPTION
Hi @erutan,

I haven't figured out a sustainable workflow to integrate your work from this repo into the Angular 2 code-base we are working on yet (we are using Webpack). In the meantime, we'll need a way to specify an alternate destination directory to which your Gulp build will write the compiled assets. This PR adds that ability.

Example:

`gulp build --production --dest=logon` will write all built files to `./logon` instead of `./dist`. It defaults to `dist`, however, so that your existing workflow will remain the same.