### PR TITLE
Override `display: none;` with `.show`

### DIFF
--- a/src/assets/scss/components/_mfa.scss
+++ b/src/assets/scss/components/_mfa.scss
@@ -1,5 +1,8 @@
 .mfa .supporting-info {
   display: none;
+  &.show {
+    display: block;
+  }
   @include breakpoint(multi-column) {
     display: block;
   }


### PR DESCRIPTION
Hi @erutan,

In order to implement the __`Get Help / More Information`__ toggle on mobile, I needed a way to override the `display: none;` CSS rule on `.mfa .supporting-info` on mobile. I could use inline styles, but I thought adding a class is a cleaner approach.

Let me know what you think and if there is a more elegant solution.