### PR TITLE
Sync up ActiveLAMP work

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "bower_components/foundation-sites"]
-	path = bower_components/foundation-sites
-	url = https://github.com/ucla/foundation-sites.git
-	branch = develop

--- a/src/assets/scss/components/_mfa.scss
+++ b/src/assets/scss/components/_mfa.scss
@@ -75,9 +75,10 @@ fieldgroup.inline {
 }
 
 @mixin notification-banner($background: $ucla-blue, $color: $white) {
-  position: absolute;
+  position: fixed;
   top: 0;
-  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
   @include grid-row();
   width: 100%;
   height: $global-spacing * 3;


### PR DESCRIPTION
1. Removal of `.gitmodules` file
2. Support for `--no_styleguide` flag to disable generation of styleguide.
3. Support for `--no_uncss` flag to disable piping to `uncss`

    Useful for instances where we add styles that are only used within Angular 2 component code & templates but is yet to be used within the prototype screens.
4. Centralize alert banner placement.