### PR TITLE
Updates from ActiveLAMP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ADD . /var/templates/src
 
 RUN npm install && bower --allow-root install && node_modules/.bin/gulp build --dest=/var/templates/dist --production --no_styleguide
 
-CMD ["node_modules/.bin/gulp", "--dest=/var/templates/dist", "--no_styleguide"]
+CMD ["node_modules/.bin/gulp", "--dest=/var/templates/dist", "--no_styleguide", "--no_uncss"]
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN npm install && bower --allow-root install && node_modules/.bin/gulp build --
 
 CMD ["node_modules/.bin/gulp", "--dest=/var/templates/dist", "--no_styleguide", "--no_uncss"]
 
+EXPOSE 8000
+
 
 
 

--- a/bower.json
+++ b/bower.json
@@ -20,14 +20,12 @@
     "motion-ui": "~1.2.2",
     "sass-toolkit": "~2.10.2",
     "what-input": "^1.2.5",
-    "zxcvbn": "~4.2.0"
+    "zxcvbn": "~4.2.0",
+    "spin.js": "^2.3.2"
   },
   "resolutions": {
     "jquery": "1.12.4",
     "what-input": "1.2.5"
   },
-  "private": true,
-  "devDependencies": {
-    "spin.js": "^2.3.2"
-  }
+  "private": true
 }

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,4 @@
 # Your project's server will run on localhost:xxxx at this port
-PORT: 8000
-
 # Autoprefixer will make sure your CSS works with these browsers
 COMPATIBILITY:
   - "last 2 versions"

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,6 @@
 # Your project's server will run on localhost:xxxx at this port
+PORT: 8000
+
 # Autoprefixer will make sure your CSS works with these browsers
 COMPATIBILITY:
   - "last 2 versions"

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -10,6 +10,7 @@ import rimraf   from 'rimraf';
 import sherpa   from 'style-sherpa';
 import yaml     from 'js-yaml';
 import fs       from 'fs';
+import path     from 'path';
 
 // Load all Gulp plugins into one variable
 const $ = plugins();
@@ -18,9 +19,16 @@ const $ = plugins();
 const PRODUCTION = !!(yargs.argv.production);
 const NO_STYLEGUIDE = !!(yargs.argv.no_styleguide);
 const NO_UNCSS = !!(yargs.argv.no_uncss);
+const DESTINATION = yargs.argv.dest;
 
 // Load settings from settings.yml
 const { COMPATIBILITY, PORT, UNCSS_OPTIONS, PATHS } = loadConfig();
+
+PATHS.dist = DESTINATION || PATHS.dist;
+
+if (DESTINATION) {
+  gutil.log(gutil.colors.yellow(`Overriding destination: ${DESTINATION}`));
+}
 
 function loadConfig() {
   let ymlFile = fs.readFileSync('config.yml', 'utf8');
@@ -38,7 +46,7 @@ gulp.task('default',
 // Delete the "dist" folder
 // This happens every time a build starts
 function clean(done) {
-  rimraf(PATHS.dist, done);
+  rimraf(path.join(PATHS.dist, '*'), done);
 }
 
 // Copy files out of the assets folder

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "gulp",
     "build": "gulp build --production",
+    "deploy-build": "gulp build --production --no_styleguide --no_uncss",
     "update-git-ref": "sed -i '' \"s/foundation-sites#[a-z0-9]*/foundation-sites#$(cd bower_components/foundation-sites; git rev-parse HEAD)/\" bower.json"
   },
   "author": "ZURB <foundation@zurb.com>",

--- a/src/assets/scss/components/_logon.scss
+++ b/src/assets/scss/components/_logon.scss
@@ -281,6 +281,3 @@ dl.info-list {
   }
 }
 
-.alert-text {
-  color: $alert-color;
-}

--- a/src/assets/scss/components/_logon.scss
+++ b/src/assets/scss/components/_logon.scss
@@ -280,3 +280,7 @@ dl.info-list {
     }
   }
 }
+
+.alert-text {
+  color: $alert-color;
+}

--- a/src/assets/scss/components/_mfa.scss
+++ b/src/assets/scss/components/_mfa.scss
@@ -21,7 +21,13 @@ fieldgroup.inline {
   @include breakpoint(multi-column) {
     display: none;
   }
-  margin-top: $global-margin;
+
+  margin-top: $global-margin * 5;
+
+  @include breakpoint($topbar-unstack-breakpoint) {
+    margin-top: $global-margin;
+  }
+
   background: $nav-background;
   p {
     margin-bottom: 0;


### PR DESCRIPTION
1. ~~`.alert-text`~~

    ~~This is currently being used to color a header in the U2F screen pink; will post a screenshot of that in a bit. If I should be using a different class, let me know.~~

2. Bring back `--dest` support to override where Gulp sends the compiled assets.

   We need this for our Docker development environment. Another change is that we only let `rimraf` to delete only the contents of the destination folder and not the folder itself -- in Docker this folder is something we can't delete.

3. `EXPOSE 8000` in Docker image

   Another requirement in our dev build :)

3. Pass `--no_uncss` during Docker build.