### PR TITLE
Adding errors as a src for sass

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -104,7 +104,7 @@ function fa() {
 // Compile Sass into CSS
 // In production, the CSS is compressed
 function sass() {
-  return gulp.src('src/assets/scss/app.scss')
+  return gulp.src(['src/assets/scss/app.scss', 'src/assets/scss/errors.scss'])
     .pipe($.sourcemaps.init())
     .pipe($.sass({
       includePaths: PATHS.sass


### PR DESCRIPTION
Adding the `errors.scss` as another source for 404 page to display with the limited css.